### PR TITLE
updating module for RHEL 8 compatibility

### DIFF
--- a/manifests/addon/python.pp
+++ b/manifests/addon/python.pp
@@ -17,14 +17,24 @@ class abrt::addon::python (
   # http://fedoraproject.org/wiki/QA:Testcase_ABRT_python_addon
   include ::abrt
 
-  package { 'abrt-addon-python': ensure => $package_ensure, } ->
-  file { '/etc/abrt/plugins/python.conf':
-    ensure  => file,
-    content => template("${module_name}/abrt/plugins/python.conf"),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+  if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+    package { 'python3-abrt-addon': ensure => $package_ensure, } ->
+    file { '/etc/abrt/plugins/python.conf':
+      ensure  => file,
+      content => template("${module_name}/abrt/plugins/python3.conf"),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
+  } else {
+    package { 'abrt-addon-python': ensure => $package_ensure, } ->
+    file { '/etc/abrt/plugins/python.conf':
+      ensure  => file,
+      content => template("${module_name}/abrt/plugins/python.conf"),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
   }
-
   Class['abrt::addon::python'] ~> Service['abrtd']
 }

--- a/manifests/addon/python.pp
+++ b/manifests/addon/python.pp
@@ -19,7 +19,7 @@ class abrt::addon::python (
 
   if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
     package { 'python3-abrt-addon': ensure => $package_ensure, } ->
-    file { '/etc/abrt/plugins/python.conf':
+    file { '/etc/abrt/plugins/python3.conf':
       ensure  => file,
       content => template("${module_name}/abrt/plugins/python3.conf"),
       owner   => 'root',

--- a/templates/abrt/plugins/python3.conf
+++ b/templates/abrt/plugins/python3.conf
@@ -1,0 +1,5 @@
+# If set to 'no', unhandled python exceptions will be caught
+# and saved even in scripts which are run without full path
+# in sys.argv[0].
+# Default is 'yes': do not save them.
+RequireAbsolutePath = <%= scope['abrt::addon::python::require_absolute_path'] %>


### PR DESCRIPTION
This PR is for making the module compatible to RHEL 8.
the Package-name and python-version has changed in RHEL 8-Systems.

packagename old - abrt-addon-python
packagename new - python3-abrt-addon