### PR TITLE
Include gdb backtrace into email notification for C/CPP programs

### DIFF
--- a/manifests/libreport/mailx.pp
+++ b/manifests/libreport/mailx.pp
@@ -20,6 +20,7 @@ class abrt::libreport::mailx (
   $emailfrom      = "abrt@${::fqdn}",
   $emailto        = "root@${::fqdn}",
   $sendbinarydata = 'no',
+  $include_backtrace_ccpp = false,
 ) {
   include ::abrt
 

--- a/templates/libreport/events.d/mailx_event.conf.el7
+++ b/templates/libreport/events.d/mailx_event.conf.el7
@@ -17,8 +17,10 @@ EVENT=notify-dup analyzer=CCpp
     Mailx_Subject="[abrt][$(cat component)] a repeated crash has been detected" \
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 <% end -%>
-EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+EVENT=notify analyzer!=CCpp
+    reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
-EVENT=notify-dup reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+EVENT=notify-dup analyzer!=CCpp
+    reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=report_Mailx      reporter-mailx

--- a/templates/libreport/events.d/mailx_event.conf.el7
+++ b/templates/libreport/events.d/mailx_event.conf.el7
@@ -1,3 +1,17 @@
+<% if @include_backtrace_ccpp -%>
+EVENT=notify analyzer=CCpp
+    # CCpp notify event sending e-mail with full gdb backtrace
+    # extract build ids from coredump file and save them in 'build_ids' file
+    abrt-action-analyze-core --core=coredump -o build_ids >>event_log 2>&1 &&
+    # call gdb to generate backtrace with local variables, call arguments
+    # disassembly, etc. and save it in 'backtrace' file
+    abrt-action-generate-backtrace >>event_log 2>&1 &&
+    # generate 'duphash', 'crash_function' and 'backtrace_rating'
+    abrt-action-analyze-backtrace >>event_log 2>&1
+    #
+    # send e-mail
+    reporter-mailx -c /etc/libreport/plugins/mailx.conf
+<% end -%>
 EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=notify-dup reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf

--- a/templates/libreport/events.d/mailx_event.conf.el7
+++ b/templates/libreport/events.d/mailx_event.conf.el7
@@ -18,9 +18,11 @@ EVENT=notify-dup analyzer=CCpp
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 <% end -%>
 EVENT=notify analyzer!=CCpp
+    Mailx_Subject="[abrt][$(cat component)] a crash has been detected" \
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=notify-dup analyzer!=CCpp
+    Mailx_Subject="[abrt][$(cat component)] a repeated crash has been detected" \
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=report_Mailx      reporter-mailx

--- a/templates/libreport/events.d/mailx_event.conf.el7
+++ b/templates/libreport/events.d/mailx_event.conf.el7
@@ -10,7 +10,12 @@ EVENT=notify analyzer=CCpp
     abrt-action-analyze-backtrace >>event_log 2>&1
     #
     # send e-mail
+    Mailx_Subject="[abrt][$(cat component)] a crash has been detected" \
     reporter-mailx -c /etc/libreport/plugins/mailx.conf
+
+EVENT=notify-dup analyzer=CCpp
+    Mailx_Subject="[abrt][$(cat component)] a repeated crash has been detected" \
+    reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 <% end -%>
 EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 

--- a/templates/libreport/events.d/mailx_event.conf.el8
+++ b/templates/libreport/events.d/mailx_event.conf.el8
@@ -1,3 +1,18 @@
+<% if $include_backtrace_ccpp -%>
+EVENT=notify analyzer=CCpp
+    # CCpp notify event sending e-mail with full gdb backtrace
+    # extract build ids from coredump file and save them in 'build_ids' file
+    abrt-action-analyze-core --core=coredump -o build_ids >>event_log 2>&1 &&
+    # call gdb to generate backtrace with local variables, call arguments
+    # disassembly, etc. and save it in 'backtrace' file
+    abrt-action-generate-backtrace >>event_log 2>&1 &&
+    # generate 'duphash', 'crash_function' and 'backtrace_rating'
+    abrt-action-analyze-backtrace >>event_log 2>&1
+    #
+    # send e-mail
+    reporter-mailx -c /etc/libreport/plugins/mailx.conf
+<% end -%>
+
 EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=notify-dup reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf

--- a/templates/libreport/events.d/mailx_event.conf.el8
+++ b/templates/libreport/events.d/mailx_event.conf.el8
@@ -17,8 +17,10 @@ EVENT=notify-dup analyzer=CCpp
     Mailx_Subject="[abrt][$(cat component)] a repeated crash has been detected" \
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 <% end -%>
-EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+EVENT=notify analyzer!=CCpp
+    reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
-EVENT=notify-dup reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+EVENT=notify-dup analyzer!=CCpp
+    reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=report_Mailx      reporter-mailx

--- a/templates/libreport/events.d/mailx_event.conf.el8
+++ b/templates/libreport/events.d/mailx_event.conf.el8
@@ -1,4 +1,4 @@
-<% if $include_backtrace_ccpp -%>
+<% if @include_backtrace_ccpp -%>
 EVENT=notify analyzer=CCpp
     # CCpp notify event sending e-mail with full gdb backtrace
     # extract build ids from coredump file and save them in 'build_ids' file
@@ -10,9 +10,13 @@ EVENT=notify analyzer=CCpp
     abrt-action-analyze-backtrace >>event_log 2>&1
     #
     # send e-mail
+    Mailx_Subject="[abrt][$(cat component)] a crash has been detected" \
     reporter-mailx -c /etc/libreport/plugins/mailx.conf
-<% end -%>
 
+EVENT=notify-dup analyzer=CCpp
+    Mailx_Subject="[abrt][$(cat component)] a repeated crash has been detected" \
+    reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
+<% end -%>
 EVENT=notify reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=notify-dup reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf

--- a/templates/libreport/events.d/mailx_event.conf.el8
+++ b/templates/libreport/events.d/mailx_event.conf.el8
@@ -18,9 +18,11 @@ EVENT=notify-dup analyzer=CCpp
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 <% end -%>
 EVENT=notify analyzer!=CCpp
+    Mailx_Subject="[abrt][$(cat component)] a crash has been detected" \
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=notify-dup analyzer!=CCpp
+    Mailx_Subject="[abrt][$(cat component)] a repeated crash has been detected" \
     reporter-mailx --notify-only -c /etc/libreport/plugins/mailx.conf
 
 EVENT=report_Mailx      reporter-mailx


### PR DESCRIPTION
Introduced a variable include_backtrace_ccpp for abrt::libreport::mailx class. It allows to generate and send a backtrace from C/CPP program via email.